### PR TITLE
Add media picker flow to CreateEntryPage

### DIFF
--- a/lib/pages/create_entry_page.dart
+++ b/lib/pages/create_entry_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:wechat_assets_picker/wechat_assets_picker.dart';
+
+import 'edit_media_page.dart';
 
 class CreateEntryPage extends StatelessWidget {
   const CreateEntryPage({super.key});
@@ -9,8 +12,54 @@ class CreateEntryPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Create'),
       ),
-      body: const Center(
-        child: Text('TODO: Select media to create a new entry'),
+      body: Center(
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 24),
+            textStyle: Theme.of(context)
+                .textTheme
+                .headlineSmall
+                ?.copyWith(color: Colors.white),
+          ),
+          onPressed: () => _onCreatePressed(context),
+          child: const Text('Create'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onCreatePressed(BuildContext context) async {
+    final assets = await AssetPicker.pickAssets(
+      context,
+      pickerConfig: const AssetPickerConfig(
+        maxAssets: 1,
+        requestType: RequestType.common,
+      ),
+    );
+
+    if (!context.mounted || assets == null || assets.isEmpty) {
+      return;
+    }
+
+    final asset = assets.first;
+    final file = await asset.file;
+
+    if (!context.mounted || file == null) {
+      return;
+    }
+
+    final isVideo = asset.type == AssetType.video;
+    final media = EditMediaData(
+      type: isVideo ? 'video' : 'image',
+      sourceAssetId: asset.id,
+      originalFilePath: file.path,
+      originalDurationMs:
+          isVideo ? Duration(seconds: asset.duration).inMilliseconds : null,
+    );
+
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => EditMediaPage(media: media),
       ),
     );
   }

--- a/lib/pages/edit_media_page.dart
+++ b/lib/pages/edit_media_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class EditMediaData {
+  const EditMediaData({
+    required this.type,
+    required this.sourceAssetId,
+    required this.originalFilePath,
+    this.originalDurationMs,
+  }) : assert(type == 'image' || type == 'video');
+
+  final String type;
+  final String sourceAssetId;
+  final String originalFilePath;
+  final int? originalDurationMs;
+}
+
+class EditMediaPage extends StatelessWidget {
+  const EditMediaPage({super.key, required this.media});
+
+  final EditMediaData media;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = media.originalDurationMs;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Edit ${media.type == 'video' ? 'Video' : 'Image'}'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Source asset ID: ${media.sourceAssetId}'),
+            const SizedBox(height: 8),
+            Text('File path: ${media.originalFilePath}'),
+            if (duration != null) ...[
+              const SizedBox(height: 8),
+              Text('Duration: ${duration}ms'),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder content on CreateEntryPage with a prominent Create button that launches the asset picker
- collect the selected image or video metadata and navigate to a new EditMediaPage with the required payload
- add EditMediaPage along with a data model for displaying the chosen media information

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda2ff6d948328aa17bf1878a80138