### PR TITLE
Add media editing workflow with post draft review

### DIFF
--- a/lib/models/post_draft.dart
+++ b/lib/models/post_draft.dart
@@ -1,0 +1,44 @@
+class PostDraft {
+  const PostDraft({
+    required this.originalFilePath,
+    required this.type,
+    required this.description,
+    this.videoTrim,
+    this.coverFrameMs,
+    this.imageCrop,
+  }) : assert(type == 'image' || type == 'video');
+
+  final String originalFilePath;
+  final String type;
+  final String description;
+  final VideoTrimData? videoTrim;
+  final int? coverFrameMs;
+  final ImageCropData? imageCrop;
+}
+
+class VideoTrimData {
+  const VideoTrimData({
+    required this.startMs,
+    required this.endMs,
+  }) : assert(startMs >= 0 && endMs >= 0 && endMs >= startMs);
+
+  final int startMs;
+  final int endMs;
+}
+
+class ImageCropData {
+  const ImageCropData({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+    required this.rotation,
+  })  : assert(x >= 0 && y >= 0),
+        assert(width > 0 && height > 0);
+
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+  final double rotation;
+}

--- a/lib/pages/edit_media_page.dart
+++ b/lib/pages/edit_media_page.dart
@@ -1,4 +1,13 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui' show Rect;
+
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
+import 'package:video_editor_2/video_editor.dart';
+
+import '../models/post_draft.dart';
+import 'post_review_page.dart';
 
 class EditMediaData {
   const EditMediaData({
@@ -14,34 +23,535 @@ class EditMediaData {
   final int? originalDurationMs;
 }
 
-class EditMediaPage extends StatelessWidget {
+class EditMediaPage extends StatefulWidget {
   const EditMediaPage({super.key, required this.media});
 
   final EditMediaData media;
 
   @override
-  Widget build(BuildContext context) {
-    final duration = media.originalDurationMs;
+  State<EditMediaPage> createState() => _EditMediaPageState();
+}
 
+class _EditMediaPageState extends State<EditMediaPage> {
+  static const _videoTrimHeight = 72.0;
+  static const _coverSelectionHeight = 96.0;
+
+  final TextEditingController _descriptionController = TextEditingController();
+
+  VideoEditorController? _videoController;
+  bool _videoInitialized = false;
+  Object? _videoInitError;
+
+  double? _imageWidth;
+  double? _imageHeight;
+  bool _imageLoading = false;
+  bool _imageLoadFailed = false;
+
+  String _selectedAspectId = _AspectRatioOption.original.id;
+  int _rotationTurns = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.media.type == 'video') {
+      _initVideoController();
+    } else {
+      _loadImageMetadata();
+    }
+  }
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    unawaited(_videoController?.dispose());
+    super.dispose();
+  }
+
+  Future<void> _initVideoController() async {
+    final maxDuration = widget.media.originalDurationMs != null &&
+            widget.media.originalDurationMs! > 0
+        ? Duration(milliseconds: widget.media.originalDurationMs!)
+        : const Duration(days: 1);
+
+    final controller = VideoEditorController.file(
+      XFile(widget.media.originalFilePath),
+      maxDuration: maxDuration,
+      minDuration: Duration.zero,
+    );
+
+    setState(() {
+      _videoController = controller;
+    });
+
+    try {
+      await controller.initialize();
+      if (!mounted) return;
+      setState(() {
+        _videoInitialized = true;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _videoInitError = error;
+      });
+    }
+  }
+
+  Future<void> _loadImageMetadata() async {
+    setState(() {
+      _imageLoading = true;
+      _imageLoadFailed = false;
+    });
+
+    final imageProvider = Image.file(File(widget.media.originalFilePath)).image;
+    final completer = Completer<ImageInfo>();
+    late final ImageStreamListener listener;
+    final stream = imageProvider.resolve(const ImageConfiguration());
+
+    listener = ImageStreamListener(
+      (info, _) {
+        completer.complete(info);
+      },
+      onError: (error, __) {
+        completer.completeError(error);
+      },
+    );
+
+    stream.addListener(listener);
+
+    try {
+      final info = await completer.future;
+      if (!mounted) return;
+      setState(() {
+        _imageWidth = info.image.width.toDouble();
+        _imageHeight = info.image.height.toDouble();
+        _imageLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _imageLoading = false;
+        _imageLoadFailed = true;
+      });
+    } finally {
+      stream.removeListener(listener);
+    }
+  }
+
+  bool get _isVideo => widget.media.type == 'video';
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Edit ${media.type == 'video' ? 'Video' : 'Image'}'),
+        title: Text('Edit ${_isVideo ? 'Video' : 'Image'}'),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
+      body: SafeArea(
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Source asset ID: ${media.sourceAssetId}'),
-            const SizedBox(height: 8),
-            Text('File path: ${media.originalFilePath}'),
-            if (duration != null) ...[
-              const SizedBox(height: 8),
-              Text('Duration: ${duration}ms'),
-            ],
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: _isVideo ? _buildVideoEditor() : _buildImageEditor(),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _descriptionController,
+                    maxLines: null,
+                    decoration: const InputDecoration(
+                      labelText: 'Description',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _canContinue ? _onContinuePressed : null,
+                    child: const Text('Continue'),
+                  ),
+                ],
+              ),
+            ),
           ],
         ),
       ),
     );
   }
+
+  bool get _canContinue {
+    if (_isVideo) {
+      return _videoInitialized && _videoInitError == null;
+    }
+    if (_imageLoadFailed) {
+      return false;
+    }
+    return true;
+  }
+
+  Widget _buildVideoEditor() {
+    final controller = _videoController;
+    if (_videoInitError != null) {
+      return Center(
+        child: Text(
+          'Unable to load video',
+          style: Theme.of(context)
+              .textTheme
+              .bodyLarge
+              ?.copyWith(color: Theme.of(context).colorScheme.error),
+        ),
+      );
+    }
+
+    if (controller == null || !_videoInitialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Container(
+              color: Colors.black,
+              child: CropGridViewer.preview(controller: controller),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildTrimControls(controller),
+        const SizedBox(height: 16),
+        _buildCoverControls(controller),
+      ],
+    );
+  }
+
+  Widget _buildTrimControls(VideoEditorController controller) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AnimatedBuilder(
+          animation: Listenable.merge([controller, controller.video]),
+          builder: (context, _) {
+            final start = controller.startTrim;
+            final end = controller.endTrim;
+            String format(Duration d) =>
+                '${d.inMinutes.remainder(60).toString().padLeft(2, '0')}:'
+                '${d.inSeconds.remainder(60).toString().padLeft(2, '0')}';
+            return Text('Trim: ${format(start)} - ${format(end)}');
+          },
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: _videoTrimHeight,
+          child: TrimSlider(
+            controller: controller,
+            height: _videoTrimHeight,
+            horizontalMargin: 16,
+            child: TrimTimeline(
+              controller: controller,
+              padding: const EdgeInsets.only(top: 12),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCoverControls(VideoEditorController controller) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Cover Frame',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: _coverSelectionHeight,
+          child: ValueListenableBuilder(
+            valueListenable: controller.selectedCoverNotifier,
+            builder: (context, _, __) {
+              return CoverSelection(
+                controller: controller,
+                size: _coverSelectionHeight - 12,
+                quantity: 8,
+                selectedCoverBuilder: (child, size) => Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    child,
+                    Positioned.fill(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: Theme.of(context).colorScheme.primary,
+                            width: 2,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildImageEditor() {
+    if (_imageLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_imageLoadFailed) {
+      return Center(
+        child: Text(
+          'Unable to load image metadata',
+          style: Theme.of(context)
+              .textTheme
+              .bodyLarge
+              ?.copyWith(color: Theme.of(context).colorScheme.error),
+        ),
+      );
+    }
+
+    final aspect = _currentImageAspect;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(
+          child: AspectRatio(
+            aspectRatio: aspect,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final cropRect = _currentCropRect();
+                final cropLeft = constraints.maxWidth * cropRect.left;
+                final cropTop = constraints.maxHeight * cropRect.top;
+                final cropWidth = constraints.maxWidth * cropRect.width;
+                final cropHeight = constraints.maxHeight * cropRect.height;
+
+                return Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Container(
+                      color: Colors.black12,
+                      child: FittedBox(
+                        fit: BoxFit.cover,
+                        child: RotatedBox(
+                          quarterTurns: _rotationTurns % 4,
+                          child: Image.file(
+                            File(widget.media.originalFilePath),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: cropLeft,
+                      top: cropTop,
+                      width: cropWidth,
+                      height: cropHeight,
+                      child: IgnorePointer(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.primary,
+                              width: 2,
+                            ),
+                            color: Colors.black.withOpacity(0.1),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Aspect Ratio',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          children: _aspectRatioOptions.map((option) {
+            final selected = option.id == _selectedAspectId;
+            return ChoiceChip(
+              label: Text(option.label),
+              selected: selected,
+              onSelected: (value) {
+                if (value) {
+                  setState(() {
+                    _selectedAspectId = option.id;
+                  });
+                }
+              },
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Rotation',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            IconButton(
+              tooltip: 'Rotate left',
+              onPressed: () => setState(() {
+                _rotationTurns = (_rotationTurns + 1) % 4;
+              }),
+              icon: const Icon(Icons.rotate_left),
+            ),
+            IconButton(
+              tooltip: 'Rotate right',
+              onPressed: () => setState(() {
+                _rotationTurns = (_rotationTurns - 1) % 4;
+              }),
+              icon: const Icon(Icons.rotate_right),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Rect _currentCropRect() {
+    final option = _aspectRatioOptions
+        .firstWhere((element) => element.id == _selectedAspectId);
+    final aspect = option.ratio;
+    final imageAspect = _currentImageAspect;
+
+    if (aspect == null) {
+      return const Rect.fromLTWH(0, 0, 1, 1);
+    }
+
+    if (imageAspect == 0) {
+      return const Rect.fromLTWH(0, 0, 1, 1);
+    }
+
+    double cropWidth = 1.0;
+    double cropHeight = 1.0;
+
+    if (aspect > imageAspect) {
+      cropHeight = imageAspect / aspect;
+    } else {
+      cropWidth = aspect / imageAspect;
+    }
+
+    final left = (1 - cropWidth) / 2;
+    final top = (1 - cropHeight) / 2;
+    return Rect.fromLTWH(left, top, cropWidth, cropHeight);
+  }
+
+  double get _currentImageAspect {
+    final width = _imageWidth ?? 1;
+    final height = _imageHeight ?? 1;
+    if (height == 0 || width == 0) {
+      return 1;
+    }
+    final baseAspect = width / height;
+    return _rotationTurns.isOdd ? 1 / baseAspect : baseAspect;
+  }
+
+  void _onContinuePressed() {
+    final description = _descriptionController.text.trim();
+    final draft = PostDraft(
+      originalFilePath: widget.media.originalFilePath,
+      type: widget.media.type,
+      description: description,
+      videoTrim: _buildVideoTrim(),
+      coverFrameMs: _buildCoverFrameMs(),
+      imageCrop: _buildImageCrop(),
+    );
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PostReviewPage(draft: draft),
+      ),
+    );
+  }
+
+  VideoTrimData? _buildVideoTrim() {
+    if (!_isVideo) {
+      return null;
+    }
+    final controller = _videoController;
+    if (controller == null) {
+      return null;
+    }
+    final start = controller.startTrim.inMilliseconds;
+    final end = controller.endTrim.inMilliseconds;
+    if (!controller.isTrimmed && start == 0) {
+      final duration = controller.videoDuration.inMilliseconds;
+      if (end == duration) {
+        return null;
+      }
+    }
+    return VideoTrimData(startMs: start, endMs: end);
+  }
+
+  int? _buildCoverFrameMs() {
+    if (!_isVideo) {
+      return null;
+    }
+    final controller = _videoController;
+    if (controller == null) {
+      return null;
+    }
+    return controller.selectedCoverVal?.timeMs;
+  }
+
+  ImageCropData? _buildImageCrop() {
+    if (_isVideo) {
+      return null;
+    }
+    if (_imageWidth == null || _imageHeight == null) {
+      return null;
+    }
+    final cropRect = _currentCropRect();
+    final rotation = (_rotationTurns % 4) * 90;
+    final isIdentity = cropRect.left == 0 &&
+        cropRect.top == 0 &&
+        cropRect.width == 1 &&
+        cropRect.height == 1 &&
+        rotation == 0;
+    if (isIdentity) {
+      return null;
+    }
+    return ImageCropData(
+      x: cropRect.left,
+      y: cropRect.top,
+      width: cropRect.width,
+      height: cropRect.height,
+      rotation: rotation.toDouble(),
+    );
+  }
 }
+
+class _AspectRatioOption {
+  const _AspectRatioOption(this.id, this.label, this.ratio);
+
+  final String id;
+  final String label;
+  final double? ratio;
+
+  static const original = _AspectRatioOption('original', 'Original', null);
+}
+
+const List<_AspectRatioOption> _aspectRatioOptions = [
+  _AspectRatioOption.original,
+  _AspectRatioOption('square', '1:1', 1),
+  _AspectRatioOption('fourFive', '4:5', 4 / 5),
+  _AspectRatioOption('sixteenNine', '16:9', 16 / 9),
+];

--- a/lib/pages/post_review_page.dart
+++ b/lib/pages/post_review_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/post_draft.dart';
+
+class PostReviewPage extends StatelessWidget {
+  const PostReviewPage({super.key, required this.draft});
+
+  final PostDraft draft;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Review Post'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            _ReviewTile(title: 'Type', value: draft.type),
+            _ReviewTile(title: 'File', value: draft.originalFilePath),
+            _ReviewTile(
+              title: 'Description',
+              value: draft.description.isEmpty ? '(empty)' : draft.description,
+            ),
+            if (draft.videoTrim != null)
+              _ReviewTile(
+                title: 'Video Trim',
+                value:
+                    '${draft.videoTrim!.startMs}ms - ${draft.videoTrim!.endMs}ms',
+              ),
+            if (draft.coverFrameMs != null)
+              _ReviewTile(
+                title: 'Cover Frame',
+                value: '${draft.coverFrameMs}ms',
+              ),
+            if (draft.imageCrop != null)
+              _ReviewTile(
+                title: 'Image Crop',
+                value:
+                    'x=${draft.imageCrop!.x.toStringAsFixed(3)}, y=${draft.imageCrop!.y.toStringAsFixed(3)}, '
+                    'w=${draft.imageCrop!.width.toStringAsFixed(3)}, h=${draft.imageCrop!.height.toStringAsFixed(3)}, '
+                    'rotation=${draft.imageCrop!.rotation.toStringAsFixed(0)}°',
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReviewTile extends StatelessWidget {
+  const _ReviewTile({required this.title, required this.value});
+
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a PostDraft model to capture edited media metadata
- expand EditMediaPage to support trimming videos, selecting covers, and adjusting image crop/rotation
- create a PostReviewPage to display the assembled PostDraft before posting

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dda3c8c63483288de7e18bfd124e61