### PR TITLE
Add post review upload workflow

### DIFF
--- a/lib/pages/post_review_page.dart
+++ b/lib/pages/post_review_page.dart
@@ -1,11 +1,301 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:background_downloader/background_downloader.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../models/post_draft.dart';
+import '../services/upload_service.dart';
 
-class PostReviewPage extends StatelessWidget {
+class PostReviewPage extends StatefulWidget {
   const PostReviewPage({super.key, required this.draft});
 
   final PostDraft draft;
+
+  @override
+  State<PostReviewPage> createState() => _PostReviewPageState();
+}
+
+class _PostReviewPageState extends State<PostReviewPage> {
+  late final TextEditingController _descriptionController;
+  late final UploadService _uploadService;
+  StreamSubscription<TaskUpdate>? _updateSubscription;
+  TaskUpdate? _latestUpdate;
+  String? _currentTaskId;
+  String? _postId;
+  bool _isPosting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _descriptionController = TextEditingController(text: widget.draft.description);
+    _uploadService = UploadService();
+    _updateSubscription = _uploadService.updates.listen((update) {
+      if (update.task.taskId == _currentTaskId) {
+        setState(() {
+          _latestUpdate = update;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _updateSubscription?.cancel();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handlePost() async {
+    if (_isPosting) {
+      return;
+    }
+    FocusScope.of(context).unfocus();
+    setState(() {
+      _isPosting = true;
+    });
+
+    try {
+      final result = await _uploadService.startUpload(
+        draft: widget.draft,
+        description: _descriptionController.text,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _currentTaskId = result.taskId;
+        _postId = result.postId;
+        _latestUpdate = null;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Upload started in background')),
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to start upload: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPosting = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _retryUpload() async {
+    final taskId = _currentTaskId;
+    if (taskId == null) {
+      return;
+    }
+    try {
+      await _uploadService.retryTask(taskId);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Retrying upload...')),
+        );
+      }
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to retry upload: $error')),
+        );
+      }
+    }
+  }
+
+  Widget _buildPreview() {
+    final borderRadius = BorderRadius.circular(16);
+    final trim = widget.draft.videoTrim;
+    final crop = widget.draft.imageCrop;
+
+    Widget detailsOverlay() {
+      final details = <String>[];
+      if (trim != null) {
+        details.add('Trim: ${trim.startMs}ms - ${trim.endMs}ms');
+      }
+      if (widget.draft.coverFrameMs != null) {
+        details.add('Cover @ ${widget.draft.coverFrameMs}ms');
+      }
+      if (crop != null) {
+        details.add(
+          'Crop x${crop.x.toStringAsFixed(2)}, y${crop.y.toStringAsFixed(2)}, '
+          'w${crop.width.toStringAsFixed(2)}, h${crop.height.toStringAsFixed(2)}',
+        );
+      }
+      if (details.isEmpty) {
+        return const SizedBox.shrink();
+      }
+      return Positioned(
+        left: 12,
+        right: 12,
+        bottom: 12,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.black.withOpacity(0.6),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final line in details)
+                  Text(
+                    line,
+                    style: const TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    Widget previewContent;
+    if (widget.draft.type == 'image' && !kIsWeb) {
+      previewContent = ClipRRect(
+        borderRadius: borderRadius,
+        child: Image.file(
+          File(widget.draft.originalFilePath),
+          height: 240,
+          width: double.infinity,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) {
+            return _PreviewPlaceholder(
+              icon: Icons.image_not_supported_outlined,
+              label: 'Unable to load image preview',
+            );
+          },
+        ),
+      );
+    } else {
+      previewContent = ClipRRect(
+        borderRadius: borderRadius,
+        child: _PreviewPlaceholder(
+          icon: widget.draft.type == 'video'
+              ? Icons.videocam_outlined
+              : Icons.image_outlined,
+          label: widget.draft.type == 'video'
+              ? 'Video preview unavailable'
+              : 'Preview unavailable on web',
+        ),
+      );
+    }
+
+    return Stack(
+      children: [
+        previewContent,
+        detailsOverlay(),
+      ],
+    );
+  }
+
+  Widget _buildStatusChip() {
+    if (_currentTaskId == null) {
+      return const SizedBox.shrink();
+    }
+
+    final update = _latestUpdate;
+    final status = update?.status;
+    final rawProgress = update?.progress ?? (status == TaskStatus.complete ? 1.0 : 0.0);
+    final progressValue = rawProgress.clamp(0.0, 1.0).toDouble();
+
+    String label;
+    Color background;
+    IconData icon;
+
+    switch (status) {
+      case TaskStatus.complete:
+        label = 'Upload complete';
+        background = Colors.green.shade600;
+        icon = Icons.check_circle_outline;
+        break;
+      case TaskStatus.running:
+        label = 'Uploading ${(progressValue * 100).clamp(0, 100).toStringAsFixed(0)}%';
+        background = Theme.of(context).colorScheme.primary;
+        icon = Icons.cloud_upload_outlined;
+        break;
+      case TaskStatus.failed:
+        label = 'Upload failed';
+        background = Colors.red.shade600;
+        icon = Icons.error_outline;
+        break;
+      case TaskStatus.enqueued:
+      case TaskStatus.waitingToRetry:
+      case TaskStatus.paused:
+        label = 'Waiting to upload';
+        background = Theme.of(context).colorScheme.secondary;
+        icon = Icons.schedule_outlined;
+        break;
+      case TaskStatus.canceled:
+        label = 'Upload canceled';
+        background = Colors.grey.shade600;
+        icon = Icons.cancel_outlined;
+        break;
+      case TaskStatus.notFound:
+        label = 'Upload missing';
+        background = Colors.orange.shade700;
+        icon = Icons.help_outline;
+        break;
+      default:
+        label = 'Uploading';
+        background = Theme.of(context).colorScheme.primary;
+        icon = Icons.cloud_upload_outlined;
+        break;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 18, color: Colors.white),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: const TextStyle(color: Colors.white),
+                ),
+                if (status == TaskStatus.failed) ...[
+                  const SizedBox(width: 12),
+                  TextButton(
+                    onPressed: _retryUpload,
+                    style: TextButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        if (status == TaskStatus.running)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: LinearProgressIndicator(
+              value: progressValue <= 0 || progressValue >= 1 ? null : progressValue,
+            ),
+          ),
+      ],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,33 +305,56 @@ class PostReviewPage extends StatelessWidget {
       ),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: ListView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _ReviewTile(title: 'Type', value: draft.type),
-            _ReviewTile(title: 'File', value: draft.originalFilePath),
-            _ReviewTile(
-              title: 'Description',
-              value: draft.description.isEmpty ? '(empty)' : draft.description,
+            Expanded(
+              child: ListView(
+                children: [
+                  _buildPreview(),
+                  const SizedBox(height: 16),
+                  Text(
+                    widget.draft.type.toUpperCase(),
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    widget.draft.originalFilePath,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  if (_postId != null) ...[
+                    const SizedBox(height: 8),
+                    Text('Post ID: $_postId', style: Theme.of(context).textTheme.bodySmall),
+                  ],
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _descriptionController,
+                    maxLines: 5,
+                    minLines: 3,
+                    decoration: const InputDecoration(
+                      labelText: 'Description',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  if (_currentTaskId != null) ...[
+                    const SizedBox(height: 16),
+                    _buildStatusChip(),
+                  ],
+                ],
+              ),
             ),
-            if (draft.videoTrim != null)
-              _ReviewTile(
-                title: 'Video Trim',
-                value:
-                    '${draft.videoTrim!.startMs}ms - ${draft.videoTrim!.endMs}ms',
-              ),
-            if (draft.coverFrameMs != null)
-              _ReviewTile(
-                title: 'Cover Frame',
-                value: '${draft.coverFrameMs}ms',
-              ),
-            if (draft.imageCrop != null)
-              _ReviewTile(
-                title: 'Image Crop',
-                value:
-                    'x=${draft.imageCrop!.x.toStringAsFixed(3)}, y=${draft.imageCrop!.y.toStringAsFixed(3)}, '
-                    'w=${draft.imageCrop!.width.toStringAsFixed(3)}, h=${draft.imageCrop!.height.toStringAsFixed(3)}, '
-                    'rotation=${draft.imageCrop!.rotation.toStringAsFixed(0)}°',
-              ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _isPosting ? null : _handlePost,
+              style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+              child: _isPosting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Post'),
+            ),
           ],
         ),
       ),
@@ -49,32 +362,35 @@ class PostReviewPage extends StatelessWidget {
   }
 }
 
-class _ReviewTile extends StatelessWidget {
-  const _ReviewTile({required this.title, required this.value});
+class _PreviewPlaceholder extends StatelessWidget {
+  const _PreviewPlaceholder({required this.icon, required this.label});
 
-  final String title;
-  final String value;
+  final IconData icon;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: Theme.of(context)
-                .textTheme
-                .titleMedium
-                ?.copyWith(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            value,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ],
+    return Container(
+      height: 240,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant,
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
+            const SizedBox(height: 8),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import '../models/post_draft.dart';
+
+class ApiException implements IOException {
+  ApiException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() =>
+      'ApiException(statusCode: ${statusCode ?? 'unknown'}, message: $message)';
+}
+
+class CreateUploadResponse {
+  CreateUploadResponse({
+    required this.postId,
+    required this.uploadUrl,
+    this.requiresMultipart = false,
+    Map<String, String>? headers,
+    Map<String, String>? fields,
+    this.method = 'PUT',
+    this.taskId,
+    this.fileFieldName,
+    this.contentType,
+  })  : headers = headers ?? const {},
+        fields = fields ?? const {};
+
+  factory CreateUploadResponse.fromJson(Map<String, dynamic> json) {
+    final headers = <String, String>{};
+    if (json['headers'] is Map) {
+      (json['headers'] as Map).forEach((key, value) {
+        if (key is String && value != null) {
+          headers[key] = value.toString();
+        }
+      });
+    }
+    final fields = <String, String>{};
+    if (json['fields'] is Map) {
+      (json['fields'] as Map).forEach((key, value) {
+        if (key is String && value != null) {
+          fields[key] = value.toString();
+        }
+      });
+    }
+
+    final postId = json['postId'];
+    final uploadUrl = json['uploadUrl'] ?? json['url'];
+    if (postId is! String || uploadUrl is! String) {
+      throw ApiException('Upload response missing required fields');
+    }
+
+    return CreateUploadResponse(
+      postId: postId,
+      uploadUrl: uploadUrl,
+      requiresMultipart: json['requiresMultipart'] as bool? ?? false,
+      headers: headers,
+      fields: fields,
+      method: json['method'] as String? ?? 'PUT',
+      taskId: json['taskId'] as String?,
+      fileFieldName: json['fileFieldName'] as String?,
+      contentType: json['contentType'] as String?,
+    );
+  }
+
+  final String postId;
+  final String uploadUrl;
+  final bool requiresMultipart;
+  final Map<String, String> headers;
+  final Map<String, String> fields;
+  final String method;
+  final String? taskId;
+  final String? fileFieldName;
+  final String? contentType;
+}
+
+class ApiClient {
+  ApiClient({http.Client? httpClient, String? baseUrl})
+      : _httpClient = httpClient ?? http.Client(),
+        _baseUri = Uri.parse(baseUrl ?? 'http://localhost:54321');
+
+  final http.Client _httpClient;
+  final Uri _baseUri;
+
+  Uri _resolve(String path) => _baseUri.resolve(path);
+
+  Future<CreateUploadResponse> createUpload({
+    required String type,
+    required String fileName,
+    required int fileSize,
+    String? contentType,
+  }) async {
+    final uri = _resolve('/api/uploads/create');
+    final response = await _httpClient.post(
+      uri,
+      headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+      body: jsonEncode({
+        'type': type,
+        'fileName': fileName,
+        'fileSize': fileSize,
+        if (contentType != null) 'contentType': contentType,
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ApiException(
+        'Failed to create upload: ${response.body}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    final data = jsonDecode(response.body);
+    if (data is! Map<String, dynamic>) {
+      throw ApiException('Unexpected response when creating upload');
+    }
+
+    return CreateUploadResponse.fromJson(data);
+  }
+
+  Future<void> postMetadata({
+    required String postId,
+    required String type,
+    required String description,
+    VideoTrimData? trim,
+    int? coverFrameMs,
+    ImageCropData? imageCrop,
+  }) async {
+    final uri = _resolve('/api/posts/metadata');
+    final body = <String, dynamic>{
+      'postId': postId,
+      'type': type,
+      'description': description,
+      'trim': trim == null
+          ? null
+          : {
+              'startMs': trim.startMs,
+              'endMs': trim.endMs,
+            },
+      'coverFrameMs': coverFrameMs,
+      'imageCrop': imageCrop == null
+          ? null
+          : {
+              'x': imageCrop.x,
+              'y': imageCrop.y,
+              'width': imageCrop.width,
+              'height': imageCrop.height,
+              'rotation': imageCrop.rotation,
+            },
+    }..removeWhere((key, value) => value == null);
+
+    final response = await _httpClient.post(
+      uri,
+      headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+      body: jsonEncode(body),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ApiException(
+        'Failed to post metadata: ${response.body}',
+        statusCode: response.statusCode,
+      );
+    }
+  }
+}

--- a/lib/services/upload_service.dart
+++ b/lib/services/upload_service.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:background_downloader/background_downloader.dart';
+
+import '../models/post_draft.dart';
+import 'api_client.dart';
+
+class UploadStartResult {
+  const UploadStartResult({required this.postId, required this.taskId});
+
+  final String postId;
+  final String taskId;
+}
+
+class UploadService {
+  UploadService({ApiClient? apiClient, FileDownloader? downloader})
+      : _apiClient = apiClient ?? ApiClient(),
+        _downloader = downloader ?? FileDownloader();
+
+  final ApiClient _apiClient;
+  final FileDownloader _downloader;
+
+  Stream<TaskUpdate> get updates => _downloader.updates;
+
+  Future<UploadStartResult> startUpload({
+    required PostDraft draft,
+    required String description,
+  }) async {
+    final file = File(draft.originalFilePath);
+    if (!await file.exists()) {
+      throw const FileSystemException('Original file for upload not found');
+    }
+
+    final fileSize = await file.length();
+    final fileName = file.uri.pathSegments.isNotEmpty
+        ? file.uri.pathSegments.last
+        : 'upload';
+
+    final assumedContentType = draft.type == 'image'
+        ? 'image/jpeg'
+        : 'video/mp4';
+
+    final createResponse = await _apiClient.createUpload(
+      type: draft.type,
+      fileName: fileName,
+      fileSize: fileSize,
+      contentType: assumedContentType,
+    );
+
+    final taskId = createResponse.taskId ?? createResponse.postId;
+
+    final Task task;
+    if (createResponse.requiresMultipart) {
+      task = MultipartUploadTask(
+        taskId: taskId,
+        url: createResponse.uploadUrl,
+        files: [
+          MultipartFile(
+            fieldName: createResponse.fileFieldName ?? 'file',
+            filePath: file.path,
+            filename: fileName,
+            contentType: createResponse.contentType ?? assumedContentType,
+          ),
+        ],
+        fields: createResponse.fields,
+        method: createResponse.method,
+        headers: createResponse.headers,
+      );
+    } else {
+      task = UploadTask(
+        taskId: taskId,
+        url: createResponse.uploadUrl,
+        filename: fileName,
+        filePath: file.path,
+        method: createResponse.method,
+        headers: {
+          HttpHeaders.contentTypeHeader:
+              createResponse.contentType ?? assumedContentType,
+          ...createResponse.headers,
+        },
+      );
+    }
+
+    final enqueued = await _downloader.enqueue(task);
+    if (!enqueued) {
+      throw const FileSystemException('Failed to enqueue upload task');
+    }
+
+    await _apiClient.postMetadata(
+      postId: createResponse.postId,
+      type: draft.type,
+      description: description.trim(),
+      trim: draft.videoTrim,
+      coverFrameMs: draft.coverFrameMs,
+      imageCrop: draft.imageCrop,
+    );
+
+    return UploadStartResult(postId: createResponse.postId, taskId: task.taskId);
+  }
+
+  Future<void> retryTask(String taskId) => _downloader.retryTaskWithId(taskId);
+}


### PR DESCRIPTION
## Summary
- replace the post review page with a preview-first layout that lets authors tweak descriptions, post uploads, and watch background progress
- add an upload service that creates background_downloader tasks for the original media and posts metadata immediately
- add an API client abstraction for the local upload + metadata endpoints

## Testing
- not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dda577c4688328bc914b99307582ae