### PR TITLE
Add compile-time API base URL configuration

### DIFF
--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,0 +1,4 @@
+const String API_BASE_URL = String.fromEnvironment(
+  'API_BASE_URL',
+  defaultValue: 'http://localhost:54321',
+);

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
+import '../env.dart';
 import '../models/post_draft.dart';
 
 class ApiException implements IOException {
@@ -81,7 +82,7 @@ class CreateUploadResponse {
 class ApiClient {
   ApiClient({http.Client? httpClient, String? baseUrl})
       : _httpClient = httpClient ?? http.Client(),
-        _baseUri = Uri.parse(baseUrl ?? 'http://localhost:54321');
+        _baseUri = Uri.parse(baseUrl ?? API_BASE_URL);
 
   final http.Client _httpClient;
   final Uri _baseUri;


### PR DESCRIPTION
## Summary
- introduce a compile-time `API_BASE_URL` constant in `lib/env.dart`
- update the API client to use the shared base URL constant instead of hard-coded strings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc7b019a083289e21a8b36612986d