### PR TITLE
Add mock express backend server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,33 @@
+# Mock Backend Server
+
+This directory contains a tiny Express server that mirrors the backend endpoints the app expects. Everything is in-memory and intended purely for local development.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- npm (bundled with Node.js)
+
+## Setup
+
+```bash
+cd server
+npm init -y
+npm install express
+```
+
+## Running the server
+
+```bash
+node index.js
+```
+
+By default the server listens on [http://localhost:4000](http://localhost:4000). You can override the port by setting the `PORT` environment variable before starting the server.
+
+## Available endpoints
+
+- `POST /api/uploads/create` → returns a mock `{ uploadUrl, postId }`
+- `POST /api/posts/metadata` → returns `{ ok: true }`
+- `GET /api/feed` → returns paginated mock feed posts
+- `GET /api/me/posts` → returns paginated mock posts owned by the current user
+
+Pagination is controlled by optional `page` and `pageSize` query parameters. All data is stored in-memory and resets whenever the server restarts.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,66 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+app.use(express.json());
+
+const feedPosts = Array.from({ length: 15 }).map((_, index) => ({
+  id: `feed-${index + 1}`,
+  author: index % 2 === 0 ? 'Taylor' : 'Morgan',
+  createdAt: new Date(Date.now() - index * 3600_000).toISOString(),
+  status: index % 3 === 0 ? 'processing' : 'published',
+  mediaUrl: `https://example.com/media/feed-${index + 1}.jpg`,
+  description: `Feed post number ${index + 1}`,
+}));
+
+const myPosts = Array.from({ length: 8 }).map((_, index) => ({
+  id: `me-${index + 1}`,
+  createdAt: new Date(Date.now() - index * 7200_000).toISOString(),
+  status: index % 4 === 0 ? 'processing' : 'published',
+  mediaUrl: `https://example.com/media/me-${index + 1}.jpg`,
+  description: `My post number ${index + 1}`,
+}));
+
+const paginate = (items, page = 1, pageSize = 5) => {
+  const start = (page - 1) * pageSize;
+  const data = items.slice(start, start + pageSize);
+  return {
+    page,
+    pageSize,
+    total: items.length,
+    totalPages: Math.ceil(items.length / pageSize),
+    data,
+  };
+};
+
+const generateId = (prefix) => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+app.post('/api/uploads/create', (req, res) => {
+  const postId = generateId('post');
+  const uploadUrl = `https://uploads.example.com/${postId}`;
+
+  res.json({ uploadUrl, postId });
+});
+
+app.post('/api/posts/metadata', (req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/feed', (req, res) => {
+  const page = parseInt(req.query.page, 10) || 1;
+  const pageSize = parseInt(req.query.pageSize, 10) || 5;
+
+  res.json(paginate(feedPosts, page, pageSize));
+});
+
+app.get('/api/me/posts', (req, res) => {
+  const page = parseInt(req.query.page, 10) || 1;
+  const pageSize = parseInt(req.query.pageSize, 10) || 5;
+
+  res.json(paginate(myPosts, page, pageSize));
+});
+
+app.listen(PORT, () => {
+  console.log(`Mock backend listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a lightweight Express server under server/ to stub upload and post endpoints
- return in-memory paginated data for feed and personal posts to simulate backend responses
- document setup and run instructions for the mock backend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc87e8f8c8328893ede9a127918fb