### PR TITLE
Integrate Cloudflare Stream direct upload endpoint

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -15,6 +15,19 @@ npm init -y
 npm install express
 ```
 
+The upload endpoint now integrates with Cloudflare Stream. Configure the following environment variables before running the
+server:
+
+| Variable | Description |
+| --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier. |
+| `CLOUDFLARE_API_TOKEN` | API token with Stream write permissions. |
+| `CLOUDFLARE_STREAM_MAX_DURATION_SECONDS` | (Optional) Override the reserved duration for newly minted uploads. Defaults to `3600`. |
+| `CLOUDFLARE_STREAM_UPLOAD_EXPIRY_SECONDS` | (Optional) How long the generated upload link remains valid. Defaults to `3600`. |
+| `CLOUDFLARE_STREAM_SIMPLE_UPLOAD_LIMIT_BYTES` | (Optional) Threshold for when to issue a basic form upload instead of tus. Defaults to 200 MB. |
+| `CLOUDFLARE_STREAM_ALLOWED_ORIGINS` | (Optional) Comma separated list of origins allowed to play videos. |
+| `CLOUDFLARE_STREAM_REQUIRE_SIGNED_URLS` | (Optional) Set to `true` to require signed playback URLs. |
+
 ## Running the server
 
 ```bash
@@ -25,7 +38,8 @@ By default the server listens on [http://localhost:4000](http://localhost:4000).
 
 ## Available endpoints
 
-- `POST /api/uploads/create` → returns a mock `{ uploadUrl, postId }`
+- `POST /api/uploads/create` → mints a Cloudflare Stream upload URL. Requests below 200 MB receive a simple POST upload, larger
+  files receive a tus upload URL.
 - `POST /api/posts/metadata` → returns `{ ok: true }`
 - `GET /api/feed` → returns paginated mock feed posts
 - `GET /api/me/posts` → returns paginated mock posts owned by the current user

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,196 @@ const PORT = process.env.PORT || 4000;
 
 app.use(express.json());
 
+const SIMPLE_UPLOAD_LIMIT_BYTES = (() => {
+  const raw = Number.parseInt(
+    process.env.CLOUDFLARE_STREAM_SIMPLE_UPLOAD_LIMIT_BYTES ?? '',
+    10,
+  );
+  return Number.isFinite(raw) && raw > 0 ? raw : 200 * 1024 * 1024;
+})();
+
+const DEFAULT_MAX_DURATION_SECONDS = (() => {
+  const raw = Number.parseInt(
+    process.env.CLOUDFLARE_STREAM_MAX_DURATION_SECONDS ?? '',
+    10,
+  );
+  return Number.isFinite(raw) && raw > 0 ? raw : 3600;
+})();
+
+const DEFAULT_EXPIRY_SECONDS = (() => {
+  const raw = Number.parseInt(
+    process.env.CLOUDFLARE_STREAM_UPLOAD_EXPIRY_SECONDS ?? '',
+    10,
+  );
+  return Number.isFinite(raw) && raw > 0 ? raw : 3600;
+})();
+
+const ALLOWED_ORIGINS = (process.env.CLOUDFLARE_STREAM_ALLOWED_ORIGINS
+  ? process.env.CLOUDFLARE_STREAM_ALLOWED_ORIGINS.split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean)
+  : undefined);
+
+const REQUIRE_SIGNED_URLS = /^true$/i.test(
+  process.env.CLOUDFLARE_STREAM_REQUIRE_SIGNED_URLS ?? '',
+);
+
+const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
+const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+
+const ensureCloudflareConfigured = () => {
+  if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_API_TOKEN) {
+    throw new Error(
+      'Cloudflare Stream is not configured. Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
+    );
+  }
+};
+
+const toPositiveInteger = (value, fallback) => {
+  if (value == null) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const futureExpiryIsoString = (secondsFromNow) =>
+  new Date(Date.now() + secondsFromNow * 1000).toISOString();
+
+const encodeMetadataHeader = (metadata) => {
+  const entries = Object.entries(metadata)
+    .filter(([, value]) => value != null && `${value}`.length > 0)
+    .map(([key, value]) => `${key} ${Buffer.from(String(value)).toString('base64')}`);
+
+  return entries.length > 0 ? entries.join(',') : undefined;
+};
+
+const extractUidFromLocation = (location) => {
+  if (typeof location !== 'string') {
+    return undefined;
+  }
+  try {
+    const url = new URL(location);
+    const segments = url.pathname.split('/').filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : undefined;
+  } catch (error) {
+    const segments = location.split('/').filter(Boolean);
+    return segments.length > 0 ? segments[segments.length - 1] : undefined;
+  }
+};
+
+const requestCloudflareDirectUpload = async ({
+  maxDurationSeconds,
+  expiry,
+  creatorId,
+  fileName,
+}) => {
+  ensureCloudflareConfigured();
+
+  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream/direct_upload`;
+  const body = {
+    maxDurationSeconds,
+    expiry,
+    requireSignedURLs: REQUIRE_SIGNED_URLS || undefined,
+    allowedOrigins: ALLOWED_ORIGINS && ALLOWED_ORIGINS.length > 0 ? ALLOWED_ORIGINS : undefined,
+    creator: creatorId ? { id: creatorId } : undefined,
+  };
+
+  Object.keys(body).forEach((key) => {
+    if (body[key] == null) {
+      delete body[key];
+    }
+  });
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error(
+        `Failed to parse Cloudflare response (${response.status} ${response.statusText}).`,
+      );
+    }
+    throw error;
+  }
+
+  if (!response.ok || !data?.success) {
+    const errors = Array.isArray(data?.errors) ? data.errors : [];
+    const message = errors.length > 0 ? JSON.stringify(errors) : response.statusText;
+    throw new Error(`Cloudflare direct upload creation failed: ${message}`);
+  }
+
+  if (!data?.result?.uploadURL || !data?.result?.uid) {
+    throw new Error('Cloudflare direct upload response missing uploadURL or uid');
+  }
+
+  return {
+    uploadUrl: data.result.uploadURL,
+    uid: data.result.uid,
+  };
+};
+
+const requestCloudflareTusUpload = async ({
+  fileSize,
+  metadataHeader,
+  creatorId,
+}) => {
+  ensureCloudflareConfigured();
+
+  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream?direct_user=true`;
+  const headers = {
+    Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+    'Tus-Resumable': '1.0.0',
+    'Upload-Length': String(fileSize),
+  };
+
+  if (metadataHeader) {
+    headers['Upload-Metadata'] = metadataHeader;
+  }
+
+  if (creatorId) {
+    headers['Upload-Creator'] = creatorId;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => undefined);
+    throw new Error(
+      `Cloudflare tus upload creation failed (${response.status} ${response.statusText})${
+        text ? `: ${text}` : ''
+      }`,
+    );
+  }
+
+  const location = response.headers.get('Location') ?? response.headers.get('location');
+  if (!location) {
+    throw new Error('Cloudflare tus upload response missing Location header');
+  }
+
+  const uid = response.headers.get('stream-media-id') ?? extractUidFromLocation(location);
+  if (!uid) {
+    throw new Error('Unable to determine Cloudflare stream UID for tus upload');
+  }
+
+  return {
+    uploadUrl: location,
+    uid,
+  };
+};
+
 const feedPosts = Array.from({ length: 15 }).map((_, index) => ({
   id: `feed-${index + 1}`,
   author: index % 2 === 0 ? 'Taylor' : 'Morgan',
@@ -34,13 +224,87 @@ const paginate = (items, page = 1, pageSize = 5) => {
   };
 };
 
-const generateId = (prefix) => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+app.post('/api/uploads/create', async (req, res) => {
+  try {
+    const { type, fileSize, fileName, contentType, maxDurationSeconds, creatorId } = req.body ?? {};
 
-app.post('/api/uploads/create', (req, res) => {
-  const postId = generateId('post');
-  const uploadUrl = `https://uploads.example.com/${postId}`;
+    if (typeof type !== 'string' || !type) {
+      return res.status(400).json({ error: 'type is required' });
+    }
 
-  res.json({ uploadUrl, postId });
+    const size = Number(fileSize);
+    if (!Number.isFinite(size) || size <= 0) {
+      return res.status(400).json({ error: 'fileSize must be a positive number' });
+    }
+
+    const resolvedMaxDurationSeconds = toPositiveInteger(
+      maxDurationSeconds,
+      DEFAULT_MAX_DURATION_SECONDS,
+    );
+    const expirySeconds = DEFAULT_EXPIRY_SECONDS;
+    const expiry = futureExpiryIsoString(expirySeconds);
+
+    const cleanedFileName = typeof fileName === 'string' && fileName.trim().length > 0
+      ? fileName.trim()
+      : undefined;
+    const cleanedContentType = typeof contentType === 'string' && contentType.trim().length > 0
+      ? contentType.trim()
+      : undefined;
+
+    if (size <= SIMPLE_UPLOAD_LIMIT_BYTES) {
+      const directUpload = await requestCloudflareDirectUpload({
+        maxDurationSeconds: resolvedMaxDurationSeconds,
+        expiry,
+        creatorId,
+        fileName: cleanedFileName,
+      });
+
+      return res.json({
+        postId: directUpload.uid,
+        uploadUrl: directUpload.uploadUrl,
+        requiresMultipart: true,
+        method: 'POST',
+        fileFieldName: 'file',
+        taskId: directUpload.uid,
+      });
+    }
+
+    const metadataHeader = encodeMetadataHeader({
+      name: cleanedFileName,
+      filetype: cleanedContentType,
+      maxDurationSeconds: String(resolvedMaxDurationSeconds),
+      expiry,
+    });
+
+    const tusUpload = await requestCloudflareTusUpload({
+      fileSize: size,
+      metadataHeader,
+      creatorId,
+    });
+
+    return res.json({
+      postId: tusUpload.uid,
+      uploadUrl: tusUpload.uploadUrl,
+      requiresMultipart: false,
+      method: 'PATCH',
+      headers: {
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': '0',
+      },
+      contentType: 'application/offset+octet-stream',
+      taskId: tusUpload.uid,
+      tus: {
+        uploadLength: size,
+        metadata: metadataHeader,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to create upload URL', error);
+    res.status(500).json({
+      error: 'Failed to create upload URL',
+      details: error instanceof Error ? error.message : undefined,
+    });
+  }
 });
 
 app.post('/api/posts/metadata', (req, res) => {


### PR DESCRIPTION
## Summary
- connect `/api/uploads/create` to Cloudflare Stream so local development can mint direct upload URLs
- support both simple direct uploads for small files and tus uploads for larger files, including Cloudflare metadata and validation
- document the required Stream environment variables for the mock server

## Testing
- not run (Cloudflare credentials required)


------
https://chatgpt.com/codex/tasks/task_e_68ddca7e4914832893005b0d2641fd36